### PR TITLE
OPS-5656 disable sass linting for cleaner deploy

### DIFF
--- a/html/sites/all/themes/ocha_basic/gulpfile.js
+++ b/html/sites/all/themes/ocha_basic/gulpfile.js
@@ -101,7 +101,7 @@ function sassLintTask() {
 //——————————————————————————————————————————————————————————————————————————————
 // Sass
 //——————————————————————————————————————————————————————————————————————————————
-const sassTask = gulp.series(sassLintTask, sassCompileTask);
+const sassTask = gulp.series(/*sassLintTask,*/ sassCompileTask);
 exports.sass = sassTask;
 
 


### PR DESCRIPTION
 linting corrections come in later version of ocha_basic